### PR TITLE
change config check to start with ou= for OU

### DIFF
--- a/plugins/module_utils/prism/user_groups.py
+++ b/plugins/module_utils/prism/user_groups.py
@@ -43,7 +43,7 @@ class UserGroup(Prism):
         return payload, None
 
     def _build_spec_user_distinguished_name(self, payload, config):
-        if "ou=" in config:
+        if config[0:3] == "ou=":
             payload["spec"]["resources"]["directory_service_ou"] = {
                 "distinguished_name": config
             }


### PR DESCRIPTION
groups don't start with ou= but may be within an OU so would contain ou= in the string. This change makes it so groups don't have to be in the root of the AD.